### PR TITLE
implement scroll to fallback for non linear layout managers

### DIFF
--- a/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerSection.java
+++ b/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerSection.java
@@ -122,7 +122,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
                     mIsIndexing = true;
                     // Determine which section the point is in, and move the list to that section
                     mCurrentSection = getSectionByPoint(ev.getY());
-                    ((LinearLayoutManager) mRecyclerView.getLayoutManager()).scrollToPositionWithOffset(mIndexer.getPositionForSection(mCurrentSection), 0);
+                    scrollToPosition();
                     return true;
                 }
                 break;
@@ -132,7 +132,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
                     if (contains(ev.getX(), ev.getY())) {
                         // Determine which section the point is in, and move the list to that section
                         mCurrentSection = getSectionByPoint(ev.getY());
-                        ((LinearLayoutManager) mRecyclerView.getLayoutManager()).scrollToPositionWithOffset(mIndexer.getPositionForSection(mCurrentSection), 0);
+                        scrollToPosition();
                     }
                     return true;
                 }
@@ -145,6 +145,16 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
                 break;
         }
         return false;
+    }
+
+    private void scrollToPosition() {
+        int position = mIndexer.getPositionForSection(mCurrentSection);
+        RecyclerView.LayoutManager layoutManager = mRecyclerView.getLayoutManager();
+        if (layoutManager instanceof LinearLayoutManager) {
+            ((LinearLayoutManager) layoutManager).scrollToPositionWithOffset(position, 0);
+        } else {
+            layoutManager.scrollToPosition(position);
+        }
     }
 
     public void onSizeChanged(int w, int h, int oldw, int oldh) {


### PR DESCRIPTION
Hey @myinnos,
I implemented a fallback if a non linear layout manager is used.
If this happened before the app crashed because the layout manager could not be cast to a linear one.
I understand that only the linear layout manager has the method scrollToPositionWithOffset, to position the first view at top. But with the fallback the minimal functionality is working on any adapter and works the same as before for linear ones.
With the fallback your lib works perfect with https://github.com/ShamylZakariya/StickyHeaders.
This lib has a non linear adapter but scrollToPosition displays the selected position at the top by default.

