### PR TITLE
Added ability to hide the preview box

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ mRecyclerView.setIndexBarTransparentValue((float) 0.4);
 ```java
  mRecyclerView.setPreviewPadding(2);
 ```
+- Change PreviewVisibility:
+```java
+ mRecyclerView.setPreviewVisibility(false);
+```
 - Change Typeface:
 ```java
  Typeface typeface = Typeface.createFromAsset(context.getAssets(), "Custom-Font.ttf");

--- a/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerSection.java
+++ b/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerSection.java
@@ -40,6 +40,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
     private float setIndexbarWidth = IndexFastScrollRecyclerView.mIndexbarWidth;
     private float setIndexbarMargin = IndexFastScrollRecyclerView.mIndexbarMargin;
     private int setPreviewPadding = IndexFastScrollRecyclerView.mPreviewPadding;
+    private boolean previewVisibility = true;
     private int setIndexBarCornerRadius = IndexFastScrollRecyclerView.mIndexBarCornerRadius;
     private Typeface setTypeface = null;
     private Boolean setIndexBarVisibility = true;
@@ -75,7 +76,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
 
             if (mSections != null && mSections.length > 0) {
                 // Preview is shown when mCurrentSection is set
-                if (mCurrentSection >= 0) {
+                if (previewVisibility && mCurrentSection >= 0 && mSections[mCurrentSection] != "") {
                     Paint previewPaint = new Paint();
                     previewPaint.setColor(Color.BLACK);
                     previewPaint.setAlpha(96);
@@ -281,10 +282,17 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
     }
 
     /**
-     * @param status to hide or visibility index bar
+     * @param shown boolean to show or hide the index bar
      */
-    public void setIndexBarVisibility(Boolean status) {
-        setIndexBarVisibility = status;
+    public void setIndexBarVisibility(boolean shown) {
+        setIndexBarVisibility = shown;
+    }
+
+    /**
+     * @param shown boolean to show or hide the preview box
+     */
+    public void setPreviewVisibility(boolean shown) {
+        previewVisibility = shown;
     }
 
     /**

--- a/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerView.java
+++ b/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerView.java
@@ -175,10 +175,17 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
     }
 
     /**
-     * @param status Typeface to set the typeface of the preview & the index bar
+     * @param shown boolean to show or hide the index bar
      */
-    public void setIndexBarVisibility(Boolean status) {
-        mScroller.setIndexBarVisibility(status);
+    public void setIndexBarVisibility(boolean shown) {
+        mScroller.setIndexBarVisibility(shown);
+    }
+
+    /**
+     * @param shown boolean to show or hide the preview
+     */
+    public void setPreviewVisibility(boolean shown) {
+        mScroller.setPreviewVisibility(shown);
     }
 
     /**


### PR DESCRIPTION
I am using this to make an index bar that has an index from 1 to 150. I only show multiples of 10 on the bar, so it was displaying a blank preview box most of the time. I thought about just not displaying it when the index was "" (which is included in this code), but then I decided to just remove the preview altogether, and run with that, at least for now.

It also might be nice if the preview displayed a number even when the index bar had a blank string for that item, but that would require two strings per section (one for the index bar, and a different one for the preview), and I thought that might be too big a change.