### PR TITLE
Add a "transient" IndexBar hide with UI delay

### DIFF
--- a/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerSection.java
+++ b/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerSection.java
@@ -2,6 +2,7 @@ package in.myinnos.alphabetsindexfastscrollrecycler;
 
 /*
  * Created by MyInnos on 31-01-2017.
+ * Updated by AbandonedCart 07-2022.
  */
 
 import android.content.Context;
@@ -34,7 +35,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
     private int mListViewHeight;
     private int mCurrentSection = -1;
     private boolean mIsIndexing = false;
-    private RecyclerView mRecyclerView;
+    private final RecyclerView mRecyclerView;
     private SectionIndexer mIndexer = null;
     private String[] mSections = null;
     private RectF mIndexbarRect;
@@ -92,6 +93,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
         mDensity = context.getResources().getDisplayMetrics().density;
         mScaledDensity = context.getResources().getDisplayMetrics().scaledDensity;
         mRecyclerView = recyclerView;
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(context));
         //noinspection unchecked
         setAdapter(mRecyclerView.getAdapter());
 
@@ -112,7 +114,8 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
             indexbarPaint.setColor(indexbarBackgroudColor);
             indexbarPaint.setAlpha(indexbarBackgroudAlpha);
             indexbarPaint.setAntiAlias(true);
-            canvas.drawRoundRect(mIndexbarRect, setIndexBarCornerRadius * mDensity, setIndexBarCornerRadius * mDensity, indexbarPaint);
+            canvas.drawRoundRect(mIndexbarRect, setIndexBarCornerRadius * mDensity,
+                    setIndexBarCornerRadius * mDensity, indexbarPaint);
 
             if (setIndexBarStrokeVisibility) {
                 indexbarPaint.setStyle(Paint.Style.STROKE);
@@ -150,7 +153,7 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
                     canvas.drawRoundRect(previewRect, 5 * mDensity, 5 * mDensity, previewPaint);
                     canvas.drawText(mSections[mCurrentSection], previewRect.left + (previewSize - previewTextWidth) / 2 - 1
                             , previewRect.top + (previewSize - (previewTextPaint.descent() - previewTextPaint.ascent())) / 2 - previewTextPaint.ascent(), previewTextPaint);
-                    fade(300);
+                    setPreviewFadeTimeout(300);
                 }
 
                 Paint indexPaint = new Paint();
@@ -286,17 +289,12 @@ public class IndexFastScrollRecyclerSection extends RecyclerView.AdapterDataObse
 
     private Runnable mLastFadeRunnable = null;
 
-    private void fade(long delay) {
+    private void setPreviewFadeTimeout(long delay) {
         if (mRecyclerView != null) {
             if (mLastFadeRunnable != null) {
                 mRecyclerView.removeCallbacks(mLastFadeRunnable);
             }
-            mLastFadeRunnable = new Runnable() {
-                @Override
-                public void run() {
-                    mRecyclerView.invalidate();
-                }
-            };
+            mLastFadeRunnable = mRecyclerView::invalidate;
             mRecyclerView.postDelayed(mLastFadeRunnable, delay);
         }
     }

--- a/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerView.java
+++ b/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerView.java
@@ -11,7 +11,6 @@ import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Typeface;
-import android.os.Handler;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.GestureDetector;
@@ -93,10 +92,11 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
                         mEnabled = typedArray.getBoolean(R.styleable.IndexFastScrollRecyclerView_setIndexBarShown, mEnabled);
                     }
 
-                    mTransient = true;
+                    mTransient = false;
                     if (typedArray.hasValue(R.styleable.IndexFastScrollRecyclerView_setTransientIndexBar)) {
                         mTransient = typedArray.getBoolean(R.styleable.IndexFastScrollRecyclerView_setTransientIndexBar, mTransient);
                     }
+                    if (mTransient) mEnabled = false;
                     setTransientIndexBar(mTransient);
 
                     if (typedArray.hasValue(R.styleable.IndexFastScrollRecyclerView_setIndexBarColor)) {
@@ -324,7 +324,10 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
         }
     };
     public void setTransientIndexBar(boolean enabled) {
-        if (!enabled) removeCallbacks(scrollRunnable);
+        if (!enabled) {
+            removeCallbacks(scrollRunnable);
+            setIndexBarVisibility(true);
+        }
         //noinspection deprecation
         setOnScrollListener(enabled ? new RecyclerView.OnScrollListener() {
             @Override

--- a/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerView.java
+++ b/alphabetsindexfastscrollrecycler/src/main/java/in/myinnos/alphabetsindexfastscrollrecycler/IndexFastScrollRecyclerView.java
@@ -2,6 +2,7 @@ package in.myinnos.alphabetsindexfastscrollrecycler;
 
 /*
  * Created by MyInnos on 31-01-2017.
+ * Updated by AbandonedCart 07-2022.
  */
 
 import android.annotation.SuppressLint;
@@ -10,15 +11,17 @@ import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Typeface;
-
-import androidx.annotation.ColorInt;
-import androidx.annotation.ColorRes;
-import androidx.recyclerview.widget.RecyclerView;
-
+import android.os.Handler;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.recyclerview.widget.RecyclerView;
 
 @SuppressWarnings("unused")
 public class IndexFastScrollRecyclerView extends RecyclerView {
@@ -27,13 +30,14 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
     private GestureDetector mGestureDetector = null;
 
     private boolean mEnabled = true;
+    private boolean mTransient = true;
 
     public int setIndexTextSize = 12;
     public float mIndexbarWidth = 20;
-    public float mIndexbarMarginLeft = 5;
-    public float mIndexbarMarginRight = 5;
-    public float mIndexbarMarginTop = 5;
-    public float mIndexbarMarginBottom = 5;
+    public float mIndexbarMarginLeft = 2;
+    public float mIndexbarMarginRight = 2;
+    public float mIndexbarMarginTop = 2;
+    public float mIndexbarMarginBottom = 2;
     public int mPreviewPadding = 5;
     public int mIndexBarCornerRadius = 5;
     public float mIndexBarTransparentValue = (float) 0.6;
@@ -68,12 +72,11 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
         init(context, attrs);
     }
 
-
     private void init(Context context, AttributeSet attrs) {
-        
+
         if (attrs != null) {
             TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.IndexFastScrollRecyclerView);
-            
+
                 try {
                     setIndexTextSize = typedArray.getInt(R.styleable.IndexFastScrollRecyclerView_setIndexTextSize, setIndexTextSize);
                     mIndexbarWidth = typedArray.getFloat(R.styleable.IndexFastScrollRecyclerView_setIndexbarWidth, mIndexbarWidth);
@@ -89,6 +92,12 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
                     if (typedArray.hasValue(R.styleable.IndexFastScrollRecyclerView_setIndexBarShown)) {
                         mEnabled = typedArray.getBoolean(R.styleable.IndexFastScrollRecyclerView_setIndexBarShown, mEnabled);
                     }
+
+                    mTransient = true;
+                    if (typedArray.hasValue(R.styleable.IndexFastScrollRecyclerView_setTransientIndexBar)) {
+                        mTransient = typedArray.getBoolean(R.styleable.IndexFastScrollRecyclerView_setTransientIndexBar, mTransient);
+                    }
+                    setTransientIndexBar(mTransient);
 
                     if (typedArray.hasValue(R.styleable.IndexFastScrollRecyclerView_setIndexBarColor)) {
                         TypedValue tv = new TypedValue();
@@ -160,7 +169,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
                 } finally {
                     typedArray.recycle();
                 }
-                
+
                 // This line here is neccesary else the attributes won't be updated if a value is passed from XML
                 mScroller = new IndexFastScrollRecyclerSection(context, this);
                 mScroller.setIndexBarVisibility(mEnabled);
@@ -213,6 +222,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
     public void setAdapter(Adapter adapter) {
         super.setAdapter(adapter);
         if (mScroller != null)
+            //noinspection unchecked
             mScroller.setAdapter(adapter);
     }
 
@@ -308,6 +318,30 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
         mEnabled = shown;
     }
 
+    private final Runnable scrollRunnable = () -> {
+        if (mEnabled) {
+            setIndexBarVisibility(false);
+        }
+    };
+    public void setTransientIndexBar(boolean enabled) {
+        if (!enabled) removeCallbacks(scrollRunnable);
+        //noinspection deprecation
+        setOnScrollListener(enabled ? new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
+                    recyclerView.removeCallbacks(scrollRunnable);
+                    setIndexBarVisibility(true);
+                } else if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    // setIndexBarVisibility(false);
+                    recyclerView.postDelayed(scrollRunnable, 1000);
+                }
+            }
+        } : null);
+        mTransient = enabled;
+    }
+
     /**
      * @param shown boolean to show or hide the index bar
      */
@@ -326,8 +360,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
      * @param color The color for the preview box
      */
     public void setIndexBarStrokeColor(@ColorRes int color) {
-        int colorValue = getContext().getResources().getColor(color);
-        mScroller.setIndexBarStrokeColor(colorValue);
+        mScroller.setIndexBarStrokeColor(ContextCompat.getColor(getContext(), color));
     }
 
     /**
@@ -356,8 +389,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
      * @param color The color for the preview box
      */
     public void setPreviewColor(@ColorRes int color) {
-        int colorValue = getContext().getResources().getColor(color);
-        mScroller.setPreviewColor(colorValue);
+        mScroller.setPreviewColor(ContextCompat.getColor(getContext(), color));
     }
 
     /**
@@ -371,8 +403,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
      * @param color The text color for the preview box
      */
     public void setPreviewTextColor(@ColorRes int color) {
-        int colorValue = getContext().getResources().getColor(color);
-        mScroller.setPreviewTextColor(colorValue);
+        mScroller.setPreviewTextColor(ContextCompat.getColor(getContext(), color));
     }
 
     /**
@@ -400,8 +431,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
      * @param color The color for the index bar
      */
     public void setIndexBarColor(@ColorRes int color) {
-        int colorValue = getContext().getResources().getColor(color);
-        mScroller.setIndexBarColor(colorValue);
+        mScroller.setIndexBarColor(ContextCompat.getColor(getContext(), color));
     }
 
 
@@ -416,8 +446,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
      * @param color The text color for the index bar
      */
     public void setIndexBarTextColor(@ColorRes int color) {
-        int colorValue = getContext().getResources().getColor(color);
-        mScroller.setIndexBarTextColor(colorValue);
+        mScroller.setIndexBarTextColor(ContextCompat.getColor(getContext(), color));
     }
 
     /**
@@ -431,8 +460,7 @@ public class IndexFastScrollRecyclerView extends RecyclerView {
      * @param color The text color for the index bar
      */
     public void setIndexbarHighLightTextColor(@ColorRes int color) {
-        int colorValue = getContext().getResources().getColor(color);
-        mScroller.setIndexbarHighLightTextColor(colorValue);
+        mScroller.setIndexbarHighLightTextColor(ContextCompat.getColor(getContext(), color));
     }
 
     /**

--- a/alphabetsindexfastscrollrecycler/src/main/res/values/attrs.xml
+++ b/alphabetsindexfastscrollrecycler/src/main/res/values/attrs.xml
@@ -12,6 +12,7 @@
         <attr name="setIndexBarCornerRadius" format="integer" />
         <attr name="setIndexBarTransparentValue" format="float" />
         <attr name="setIndexBarShown" format="boolean" />
+        <attr name="setTransientIndexBar" format="boolean" />
         <attr name="setIndexBarColor" format="color|string" />
         <attr name="setIndexBarTextColor" format="color|string" />
         <attr name="setIndexBarHighlightTextColor" format="color|string" />


### PR DESCRIPTION
Optimized a bunch of stuff (mostly according to Android Studio) and added the option to automatically hide the bar after 1 second of idle. I didn't include an option to set the timeout, but I can if that would be preferable. The idea was to give that extra moment to make sure you were where you were trying to get, but not remain visible longer than necessary.